### PR TITLE
Dispose Scheme and Group boards when calling destroy

### DIFF
--- a/src/main/java/ora4mas/nopl/GroupBoard.java
+++ b/src/main/java/ora4mas/nopl/GroupBoard.java
@@ -161,10 +161,8 @@ public class GroupBoard extends OrgArt {
                 execLinkedOp(parentGroup, "removeSubgroup", getGrpState().getId());
             } catch (OperationException e) {
                 e.printStackTrace();
-                return; // do not call super destroy
-            }                    
+            }
         }
-        
         super.destroy();
     }
     

--- a/src/main/java/ora4mas/nopl/OrgArt.java
+++ b/src/main/java/ora4mas/nopl/OrgArt.java
@@ -130,7 +130,13 @@ public abstract class OrgArt extends Artifact implements ToXML, DynamicFactsProv
         if (updateGUIThread != null)
             updateGUIThread.interrupt();
         if (WebInterface.isRunning())
-            WebInterface.get().removeOE(oeId, getId().getName());                
+            WebInterface.get().removeOE(oeId, getId().getName());
+
+        try {
+            dispose(getId());
+        } catch (OperationException e) {
+            e.printStackTrace();
+        }
     }
     
     protected void installNormativeSignaler() {

--- a/src/main/java/ora4mas/nopl/OrgBoard.java
+++ b/src/main/java/ora4mas/nopl/OrgBoard.java
@@ -104,12 +104,10 @@ public class OrgBoard extends Artifact {
             ArtifactId aid = aids.remove(id);
             if (aid == null) {
                 failed("there is no group board for "+id);
-                return;
             }
             removeObsPropertyByTemplate("group", new Atom(id), null, null);
             
             execLinkedOp(aid, "destroy");
-            dispose(aid);
         } catch (Exception e) {
             e.printStackTrace();
         }                    
@@ -122,18 +120,16 @@ public class OrgBoard extends Artifact {
         said.set(aid);
     }
 
-    @OPERATION public void removeScheme(String id) {        
+    @OPERATION public void removeScheme(String id) {
         try {
             ArtifactId aid = aids.remove(id);
             if (aid == null) {
                 failed("there is no scheme board for "+id);
-                return;
             }
             removeObsPropertyByTemplate("scheme", new Atom(id), null, null);
             
             execLinkedOp(aid, "destroy");
-            //dispose(aid); // TODO: does not work! (test with auction example)
-        } catch (Exception e) {
+        } catch (OperationException e) {
             e.printStackTrace();
         }                    
     }

--- a/src/main/java/ora4mas/nopl/SchemeBoard.java
+++ b/src/main/java/ora4mas/nopl/SchemeBoard.java
@@ -158,22 +158,18 @@ public class SchemeBoard extends OrgArt {
      * The agent executing this operation tries to delete the scheme board artifact 
      */
     @OPERATION public void destroy() {
-        try {
-            super.destroy();
-            orgState.clearPlayers();
-            for (Group g: getSchState().getGroupsResponsibleFor()) {
-                ArtifactId aid;
-                try {
-                    aid = lookupArtifact(g.getId());
-                    if (aid != null)
-                        execLinkedOp(aid, "removeScheme", getId().getName());
-                } catch (OperationException e) {
-                    e.printStackTrace();
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        orgState.clearPlayers();
+        for (Group g: getSchState().getGroupsResponsibleFor()) {
+		    ArtifactId aid;
+		    try {
+		        aid = lookupArtifact(g.getId());
+		        if (aid != null)
+		            execLinkedOp(aid, "removeScheme", getId().getName());
+		    } catch (OperationException e) {
+		        e.printStackTrace();
+		    }
+		}
+		super.destroy();
     }
     
     @Override


### PR DESCRIPTION
- Add call to Artifact#dispose in the end of OrgArt#destroy, which is called by both SchemeBoard#destroy and GroupBoard#destroy.
- Alter OrgBoard to reflect the changes.