### PR TITLE
getOSFile() must be public to invoke specToStr externally

### DIFF
--- a/src/main/java/ora4mas/nopl/OrgBoard.java
+++ b/src/main/java/ora4mas/nopl/OrgBoard.java
@@ -95,6 +95,10 @@ public class OrgBoard extends Artifact {
         return this.oeId;
     }
 
+    public String getOSFile() {
+        return this.osFile;
+    }
+
     public String specToStr(ToXML spec, Transformer transformer) throws Exception {
         StringWriter so = new StringWriter();
         InputSource si = new InputSource(new StringReader(DOMUtils.dom2txt(spec)));


### PR DESCRIPTION
specToStr is the moise built in function to generate organization specification webpage.