### PR TITLE
fix: unordered goal dependencies

### DIFF
--- a/examples/smart-farming/ordered.xml
+++ b/examples/smart-farming/ordered.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?xml-stylesheet href="os.xsl" type="text/xsl" ?>
+
+<organisational-specification
+
+        id="joj"
+        os-version="0.7"
+
+        xmlns='http://moise.sourceforge.net/os'
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xsi:schemaLocation='http://moise.sourceforge.net/os
+                       http://moise.sourceforge.net/xml/os.xsd'>
+
+    <structural-specification>
+        <role-definitions>
+            <role id="TractorPilot" />
+            <role id="DronePilot" />
+            <role id="ProductCollector" />
+            <role id="SoilPlower">
+                <extends role="TractorPilot"/>
+            </role>
+            <role id="Harvester">
+                <extends role="TractorPilot"/>
+            </role>
+            <role id="PestController">
+                <extends role="DronePilot"/>
+            </role>
+            <role id="HumidityChecker">
+                <extends role="DronePilot"/>
+            </role>
+            <role id="Irrigator" />
+            <role id="Feeder" />
+            <role id="Vet" />
+            <role id="EggCollector">
+                <extends role="ProductCollector"/>
+            </role>
+            <role id="MilkCollector">
+                <extends role="ProductCollector"/>
+            </role>
+        </role-definitions>
+
+        <group-specification id="FarmGroup">
+            <subgroups>
+                <group-specification id="FieldGroup">
+                    <roles>
+                        <role id="SoilPlower" min="1" max="1"/>
+                        <role id="Harvester" min="1" max="1"/>
+                        <role id="Irrigator" min="1" max="1"/>
+                        <role id="HumidityChecker" min="1" max="1"/>
+                        <role id="PestController" min="1" max="1"/>
+                    </roles>
+                </group-specification>
+                <group-specification id="AnimalsGroup">
+                    <roles>
+                        <role id="Feeder" min="1" max="1"/>
+                        <role id="Vet" min="1" max="1"/>
+                        <role id="EggCollector" min="1" max="1"/>
+                        <role id="MilkCollector" min="1" max="1"/>
+                    </roles>
+                </group-specification>
+            </subgroups>
+        </group-specification>
+    </structural-specification>
+
+    <functional-specification>
+        <scheme id="FarmScheme">
+            <goal id="ManageFarm">
+                <plan operator="parallel">
+                    <goal id="ManageFields">
+                        <plan operator="parallel">
+                            <goal id="IrrigateFields">
+                                <plan operator="sequence">
+                                    <goal id="CheckSoil">
+                                        <plan operator="parallel">
+                                            <goal id="CheckTemperature" />
+                                            <goal id="CheckHumidity" />
+                                        </plan>
+                                    </goal>
+                                    <goal id="CalculateWaterNeeded" />
+                                </plan>
+                            </goal>
+                            <goal id="Harvest" />
+                            <goal id="EliminateHaunters">
+                                <plan operator="parallel">
+                                    <goal id="EliminateMoths" />
+                                    <goal id="EliminateBugs" />
+                                    <goal id="SprayPesticides">
+                                        <depends-on goal="Harvest" />
+                                    </goal>
+                                </plan>
+                            </goal>
+                            <goal id="Plough">
+                                <plan operator="parallel">
+                                    <goal id="SetWaypoints">
+                                        <plan operator="choice">
+                                            <goal id="ComputeWaypoints" />
+                                            <goal id="InputWaypoints" />
+                                        </plan>
+                                    </goal>
+                                </plan>
+                            </goal>
+                        </plan>
+                    </goal>
+                    <goal id="ManageAnimals">
+                        <plan operator="parallel">
+                            <goal id="FeedAnimals" />
+                            <goal id="CollectProducts">
+                                <plan operator="parallel">
+                                    <goal id="CollectEggs" />
+                                    <goal id="CollectMilk">
+                                        <depends-on goal="FeedAnimals" />
+                                    </goal>
+                                </plan>
+                            </goal>
+                            <goal id="HealthCheckUp">
+                                <depends-on goal="FeedAnimals" />
+                            </goal>
+                        </plan>
+                    </goal>
+                </plan>
+            </goal>
+            <mission id="mission1">
+                <goal id="ManageFarm" />
+            </mission>
+        </scheme>
+    </functional-specification>
+
+    <normative-specification>
+        <norm id="norm1" role="TractorPilot" type="obligation" mission="mission1" />
+    </normative-specification>
+
+</organisational-specification>

--- a/examples/smart-farming/unordered.xml
+++ b/examples/smart-farming/unordered.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?xml-stylesheet href="os.xsl" type="text/xsl" ?>
+
+<organisational-specification
+
+        id="joj"
+        os-version="0.7"
+
+        xmlns='http://moise.sourceforge.net/os'
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xsi:schemaLocation='http://moise.sourceforge.net/os
+                       http://moise.sourceforge.net/xml/os.xsd'>
+
+    <structural-specification>
+        <role-definitions>
+            <role id="TractorPilot" />
+            <role id="DronePilot" />
+            <role id="ProductCollector" />
+            <role id="SoilPlower">
+                <extends role="TractorPilot"/>
+            </role>
+            <role id="Harvester">
+                <extends role="TractorPilot"/>
+            </role>
+            <role id="PestController">
+                <extends role="DronePilot"/>
+            </role>
+            <role id="HumidityChecker">
+                <extends role="DronePilot"/>
+            </role>
+            <role id="Irrigator" />
+            <role id="Feeder" />
+            <role id="Vet" />
+            <role id="EggCollector">
+                <extends role="ProductCollector"/>
+            </role>
+            <role id="MilkCollector">
+                <extends role="ProductCollector"/>
+            </role>
+        </role-definitions>
+
+        <group-specification id="FarmGroup">
+            <subgroups>
+                <group-specification id="FieldGroup">
+                    <roles>
+                        <role id="SoilPlower" min="1" max="1"/>
+                        <role id="Harvester" min="1" max="1"/>
+                        <role id="Irrigator" min="1" max="1"/>
+                        <role id="HumidityChecker" min="1" max="1"/>
+                        <role id="PestController" min="1" max="1"/>
+                    </roles>
+                </group-specification>
+                <group-specification id="AnimalsGroup">
+                    <roles>
+                        <role id="Feeder" min="1" max="1"/>
+                        <role id="Vet" min="1" max="1"/>
+                        <role id="EggCollector" min="1" max="1"/>
+                        <role id="MilkCollector" min="1" max="1"/>
+                    </roles>
+                </group-specification>
+            </subgroups>
+        </group-specification>
+    </structural-specification>
+
+    <functional-specification>
+        <scheme id="FarmScheme">
+            <goal id="ManageFarm">
+                <plan operator="parallel">
+                    <goal id="ManageFields">
+                        <plan operator="parallel">
+                            <goal id="IrrigateFields">
+                                <plan operator="sequence">
+                                    <goal id="CheckSoil">
+                                        <plan operator="parallel">
+                                            <goal id="CheckTemperature" />
+                                            <goal id="CheckHumidity" />
+                                        </plan>
+                                    </goal>
+                                    <goal id="CalculateWaterNeeded" />
+                                </plan>
+                            </goal>
+                            <goal id="EliminateHaunters">
+                                <plan operator="parallel">
+                                    <goal id="EliminateMoths" />
+                                    <goal id="EliminateBugs" />
+                                    <goal id="SprayPesticides">
+                                        <depends-on goal="Harvest" />
+                                    </goal>
+                                </plan>
+                            </goal>
+                            <goal id="Harvest" />
+                            <goal id="Plough">
+                                <plan operator="parallel">
+                                    <goal id="SetWaypoints">
+                                        <plan operator="choice">
+                                            <goal id="ComputeWaypoints" />
+                                            <goal id="InputWaypoints" />
+                                        </plan>
+                                    </goal>
+                                </plan>
+                            </goal>
+                        </plan>
+                    </goal>
+                    <goal id="ManageAnimals">
+                        <plan operator="parallel">
+                            <goal id="CollectProducts">
+                                <plan operator="parallel">
+                                    <goal id="CollectEggs" />
+                                    <goal id="CollectMilk">
+                                        <depends-on goal="FeedAnimals" />
+                                    </goal>
+                                </plan>
+                            </goal>
+                            <goal id="FeedAnimals" />
+                            <goal id="HealthCheckUp">
+                                <depends-on goal="FeedAnimals" />
+                            </goal>
+                        </plan>
+                    </goal>
+                </plan>
+            </goal>
+            <mission id="mission1">
+                <goal id="ManageFarm" />
+            </mission>
+        </scheme>
+    </functional-specification>
+
+    <normative-specification>
+        <norm id="norm1" role="TractorPilot" type="obligation" mission="mission1" />
+    </normative-specification>
+
+</organisational-specification>

--- a/src/main/java/moise/os/fs/Goal.java
+++ b/src/main/java/moise/os/fs/Goal.java
@@ -335,10 +335,11 @@ public class Goal extends MoiseElement implements ToXML, ToProlog {
             if (ea.hasAttribute("goal")) {
                 String goalId = ea.getAttribute("goal");
                 Goal dog = sch.getGoal(goalId);
-                if (dog != null)
-                    addDependence(dog);
-                else
-                    System.out.println("The goal "+goalId+" was not declared in the scheme and thus can not be used as a depends-on argument for "+this);
+                if (dog == null) {
+                    dog = new Goal(goalId);
+                    sch.addGoal(dog);
+                }
+                addDependence(dog);
             }
         }
 

--- a/src/main/java/moise/os/fs/Plan.java
+++ b/src/main/java/moise/os/fs/Plan.java
@@ -3,6 +3,7 @@ package moise.os.fs;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import moise.common.MoiseConsistencyException;
 import moise.common.MoiseElement;
@@ -225,7 +226,8 @@ public class Plan extends MoiseElement implements ToXML, ToProlog {
 
         // goals
         for (Element eg: DOMUtils.getDOMDirectChilds(ele, Goal.getXMLTag())) {
-            Goal gs = new Goal(eg.getAttribute("id"));
+            String goalId = eg.getAttribute("id");
+            Goal gs = Optional.ofNullable(sch.getGoal(goalId)).orElseGet(() -> new Goal(goalId));
             gs.setInPlan(this);
             sch.addGoal(gs);
             gs.setFromDOM(eg, sch);

--- a/src/test/java/moise/DependenciesOrderTest.java
+++ b/src/test/java/moise/DependenciesOrderTest.java
@@ -1,0 +1,35 @@
+package moise;
+
+import moise.os.OS;
+import moise.os.fs.FS;
+import moise.os.fs.Goal;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DependenciesOrderTest {
+    @Test
+    public void dependenciesOrderTest() {
+        FS orderedFS = Objects.requireNonNull(OS.loadOSFromURI("examples/smart-farming/ordered.xml")).getFS();
+        FS unorderedFS = Objects.requireNonNull(OS.loadOSFromURI("examples/smart-farming/unordered.xml")).getFS();
+
+        dependenciesEqualityTest(orderedFS, unorderedFS);
+        schemeGoalsEqualityTest(orderedFS, unorderedFS);
+    }
+
+    private void dependenciesEqualityTest(FS o, FS u) {
+        assertEquals(
+                o.findGoal("SprayPesticides").getDependencies(),
+                u.findGoal("SprayPesticides").getDependencies());
+    }
+
+    private void schemeGoalsEqualityTest(FS o, FS u) {
+        Collection<Goal> oGoals = o.findScheme("FarmScheme").getGoals();
+        Collection<Goal> uGoals = u.findScheme("FarmScheme").getGoals();
+        assertTrue(oGoals.size() == uGoals.size() && oGoals.containsAll(uGoals) && uGoals.containsAll(oGoals));
+    }
+}


### PR DESCRIPTION
It is now possible to create a scheme even when the dependency from a goal is added before the goal declaration itself.
I am open to suggestions on how to test the fix more accurately.


This used to be the only way to define dependencies:
```XML
<goal id="g1" />
<goal id="g2">
    <depends-on goal="g1" />
</goal>
```
Now, this is also acceptable:
```XML
<goal id="g2">
    <depends-on goal="g1" />
</goal>
<goal id="g1" />
```
